### PR TITLE
"requiredExtensions" extension API

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1061,7 +1061,7 @@ class Runtime extends EventEmitter {
      * @param {ExtensionMetadata} extensionInfo - information about the extension (id, blocks, etc.)
      * @private
      */
-     async _registerExtensionPrimitives (extensionInfo) {
+    async _registerExtensionPrimitives (extensionInfo) {
 
         // If the extension requires other extensions, load them first.
         if (Array.isArray(extensionInfo.requiredExtensions)) {
@@ -1073,7 +1073,9 @@ class Runtime extends EventEmitter {
                 ) {
                     this.extensionManager.loadExtensionURL(extensionId);
                 } else {
-                    console.warn(`Failed to load required extension: ${extensionId} for extension: ${extensionInfo.id}`);
+                    console.warn(
+                        `Failed to load required extension: ${extensionId} for extension: ${extensionInfo.id}`
+                    );
                 }
             }
         }

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1061,7 +1061,23 @@ class Runtime extends EventEmitter {
      * @param {ExtensionMetadata} extensionInfo - information about the extension (id, blocks, etc.)
      * @private
      */
-    _registerExtensionPrimitives (extensionInfo) {
+     async _registerExtensionPrimitives (extensionInfo) {
+
+        // If the extension requires other extensions, load them first.
+        if (Array.isArray(extensionInfo.requiredExtensions)) {
+            for (const extensionId of extensionInfo.requiredExtensions) {
+                if (
+                    this.extensionManager.isCoreExtension(extensionId) ||
+                    this.extensionManager.isBuiltinExtension(extensionId) ||
+                    await this.extensionManager.securityManager.canLoadExtensionFromProject(extensionId)
+                ) {
+                    this.extensionManager.loadExtensionURL(extensionId);
+                } else {
+                    console.warn(`Failed to load required extension: ${extensionId} for extension: ${extensionInfo.id}`);
+                }
+            }
+        }
+
         const categoryInfo = {
             id: extensionInfo.id,
             name: maybeFormatMessage(extensionInfo.name),

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -37,7 +37,7 @@ const coreExtensions = [
     'control',
     'sensing',
     'operators',
-    'variables',
+    'data',
     'json',
     'procedures',
     'comments'

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -29,6 +29,20 @@ const defaultBuiltinExtensions = {
     tw: () => require('../extensions/tw')
 };
 
+const coreExtensions = [
+    'motion',
+    'looks',
+    'sound',
+    'events',
+    'control',
+    'sensing',
+    'operators',
+    'variables',
+    'JSON',
+    'myBlocks',
+    'Comments'
+];
+
 /**
  * @typedef {object} ArgumentInfo - Information about an extension block argument
  * @property {ArgumentType} type - the type of value this argument can take
@@ -126,6 +140,7 @@ class ExtensionManager {
         this.asyncExtensionsLoadedCallbacks = [];
 
         this.builtinExtensions = Object.assign({}, defaultBuiltinExtensions);
+        this.coreExtensions = coreExtensions;
 
         dispatch.setService('extensions', createExtensionService(this)).catch(e => {
             log.error(`ExtensionManager was unable to register extension service: ${JSON.stringify(e)}`);
@@ -151,6 +166,16 @@ class ExtensionManager {
      */
     isBuiltinExtension (extensionId) {
         return Object.prototype.hasOwnProperty.call(this.builtinExtensions, extensionId);
+    }
+
+    /**
+     * Determine whether an extension with a given ID is registered as a core extension in the VM, such as motion.
+     * Note that custom extensions or extensions that don't load on startup will return false here.
+     * @param {string} extensionId
+     * @returns {boolean}
+     */
+    isCoreExtension (extensionId) {
+        return this.coreExtensions.includes(extensionId);
     }
 
     /**
@@ -207,8 +232,8 @@ class ExtensionManager {
             return;
         }
 
-        if (this.isExtensionURLLoaded(extensionURL)) {
-            // Extension is already loaded.
+        if (this.isExtensionURLLoaded(extensionURL) || this.isCoreExtension(extensionURL)) {
+            // Extension is already loaded or is a core extension.
             return;
         }
 

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -38,9 +38,9 @@ const coreExtensions = [
     'sensing',
     'operators',
     'variables',
-    'JSON',
-    'myBlocks',
-    'Comments'
+    'json',
+    'procedures',
+    'comments'
 ];
 
 /**


### PR DESCRIPTION
This adds the ability for extensions to have the "requiredExtensions" attribute in the extensions info in which the VM will attempt to load the extensions if not already added. Below is a mock-up extension I used in which everything seems to work as expected.
```
(async Scratch => {
    class Extension {
        getInfo(){return {
            id: "testing",
            name: "Testing EXT",
            blocks: [],
            requiredExtensions: [
                "pen",
                "motion",
                "https://sharkpools-extensions.vercel.app/extension-code/Turbo-Skins.js",
                "https://extensions.turbowarp.org/fetch.js",
                "https://extensions.turbowarp.org/runtime-options.js"
            ]
        }}
    }
    Scratch.extensions.register(new Extension);
})(Scratch);
```